### PR TITLE
Removed unused using that breaks on Unity 6

### DIFF
--- a/HDRP Code Injection/HDUtilsExtension.cs
+++ b/HDRP Code Injection/HDUtilsExtension.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using UnityEngine;
-using UnityEngine.Experimental.Rendering.RenderGraphModule;
 using System;
 using System.Linq.Expressions;
 using System.Reflection;


### PR DESCRIPTION
Hello,
This PR fixes the compilation on Unity 6 by removing an unused using